### PR TITLE
#162132648 Build a stats page that displays the number of  resolved, unresolved and rejected red-flag/intervention records

### DIFF
--- a/UI/css/styles.css
+++ b/UI/css/styles.css
@@ -507,3 +507,96 @@ body {
 .modify a ~ a {
   border-left: 1px solid #f32;
 }
+
+
+
+/* STATS SECTION STYLES */
+
+.stats-content {
+  flex: 1;
+  margin-top: 2em;
+  margin-bottom: 3em;
+  padding: 2em;
+}
+
+.stats-main {
+  width: 50%;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+
+
+
+
+
+.stats-main table {
+  border-collapse: separate;
+  border-spacing: 0;
+  color: #4a4a4d;
+  font: sans-serif;
+  font-size: 1.2em;
+}
+.stats-main th,
+.stats-main td {
+  padding: 10px 15px;
+  vertical-align: middle;
+}
+.stats-main thead {
+  background: #395870;
+  background: linear-gradient(#49708f, #293f50);
+  color: #fff;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.stats-main th:first-child {
+  border-top-left-radius: 5px;
+  text-align: left;
+}
+.stats-main th:last-child {
+  border-top-right-radius: 5px;
+}
+.stats-main tbody tr:nth-child(even) {
+  background: #f0f0f2;
+}
+.stats-main td {
+  border-bottom: 1px solid #cecfd5;
+  border-right: 1px solid #cecfd5;
+}
+.stats-main td:first-child {
+  border-left: 1px solid #cecfd5;
+}
+.record-title {
+  color: #395870;
+  display: block;
+}
+.text-offset {
+  color: #7c7c80;
+  font-size: 12px;
+}
+.resolved,
+.not-resolved {
+  text-align: center;
+}
+.rejected {
+  text-align: right;
+}
+.item-multiple {
+  display: block;
+}
+.stats-main tbody {
+  text-align: right;
+}
+.stats-main tbody tr:last-child {
+  background: #f0f0f2;
+  color: #395870;
+  font-weight: bold;
+}
+.stats-main tbody tr:last-child td:first-child {
+  border-bottom-left-radius: 5px;
+}
+.stats-main tbody tr:last-child td:last-child {
+  border-bottom-right-radius: 5px;
+}
+
+

--- a/UI/stats.html
+++ b/UI/stats.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+</head>
+<body>
+
+</body>
+</html>

--- a/UI/stats.html
+++ b/UI/stats.html
@@ -1,9 +1,88 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-	<title></title>
+	<title>Stats - iReporter</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, scale=1">
+	<link rel="stylesheet" type="text/css" href="css/styles.css">
 </head>
+
 <body>
+
+	<header class="header">
+		<div class="container top-nav">
+			<nav>
+				<ul class="header-nav nav-links">
+					<li><a href="#">Home</a></li>
+					<li><a href="stats.html">Stats</a></li>
+					<li><a href="profile.html">Profile</a></li>
+					<li><a href="#" class="tagged btn-nav">Add Record</a></li>
+					<li><a href="#">Sign out</a></li>
+				</ul>
+			</nav>
+			<a href="index.html" class="logo">
+				iReporter
+			</a>
+		</div>
+	</header>
+
+	<section class="stats-content">
+		<div class="container">
+			<div class="stats-main">
+				<table>
+				  <thead>
+				    <tr>
+				      <th scope="col">Record Type</th>
+				      <th scope="col">Resolved</th>
+				      <th scope="col">Not yet resolved</th>
+				      <th scope="col">rejected</th>
+				    </tr>
+				  </thead>
+				  <tbody>
+				    <tr>
+				      <td>
+				        <strong class="record-title">Red Flag</strong>
+				      </td>
+				      <td class="resolved">0</td>
+				      <td class="not-resolved">0</td>
+				      <td class="rejected">0</td>
+				    </tr>
+
+				    <tr>
+				      <td>
+				        <strong class="record-title">Intervention</strong>
+				      </td>
+				      <td class="resolved">0</td>
+				      <td class="not-resolved">0</td>
+				      <td class="rejected">0</td>
+				    </tr>
+
+				    <tr>
+				      <td>
+				        <strong class="record-title">Total</strong>
+				      </td>
+				      <td class="resolved">0</td>
+				      <td class="not-resolved">0</td>
+				      <td class="rejected">0</td>
+				    </tr>
+
+				  </tbody>
+	
+				</table>
+			</div>
+			
+
+		</div>
+	</section>
+
+
+	<footer class="footer">
+	  <div class="container">
+	    <p>&copy; iReporter.</p>
+	  </div>
+	</footer>
+
 
 </body>
 </html>


### PR DESCRIPTION
#### What does this PR do?
Build a stats page that displays the number of  resolved, unresolved(in draft/under investigation) and rejected red-flag/intervention records

#### Description of Task to be completed?
Display a statistics page with the number of  resolved, unresolved(in draft/under investigation) and rejected red-flag/intervention records. The data is filled in a clearly formatted table.

#### How should this be manually tested?
Clone the repo, checkout the ft-statistics-page-#162132648 and use your favorite browser to open the stats.html file

#### Any background context you want to provide?
The stats page is only a mock up. It is a static page with no back-end functionality implemented

#### What are the relevant pivotal tracker stories?
#162132648

#### Screenshots (if appropriate)
![stats](https://user-images.githubusercontent.com/10455781/48944139-990f7680-ef36-11e8-9141-d86db81ae387.png)
